### PR TITLE
A1100 boot to GUI fixes

### DIFF
--- a/hw/eos/engine.c
+++ b/hw/eos/engine.c
@@ -1208,9 +1208,10 @@ unsigned int eos_handle_jpcore(unsigned int parm, unsigned int address, unsigned
                 /* EOSM: this value starts JPCORE, but fails the DCIM test */
                 //ret = 0x1010000;
 
-                if (strcmp(eos_state->model->name, "1300D") == 0)
+                if (strcmp(eos_state->model->name, "1300D") == 0
+                    || strcmp(eos_state->model->name, "A1100") == 0)
                 {
-                    /* 1300D requires it */
+                    /* 1300D, A1100 requires it (A1100 avoids HardwareDefect in ffcbb5bc)  */
                     ret = 0x1010000;
                 }
             }
@@ -1245,7 +1246,9 @@ unsigned int eos_handle_jpcore(unsigned int parm, unsigned int address, unsigned
             msg = "interrupt status? (70D loop)";
             ret = rand();
 
-            if (strcmp(eos_state->model->name, "1300D") == 0)
+            if (strcmp(eos_state->model->name, "1300D") == 0
+                // A1100 avoids HardwareDefect in ffcbb8f0
+                || strcmp(eos_state->model->name, "A1100") == 0)
             {
                 ret = 0x400;
             }

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -665,6 +665,21 @@ static void eos_rom_write(void *opaque, hwaddr addr, uint64_t value, uint32_t si
         }
     }
 
+    // flash control registers at 0xffc00aaa and 0xffc00554, see ffdf4e58 and
+    // ffdf4dec which are copied to ITCM at 0x1b0 by ffdf5024 depending on
+    // operation
+    // writes to registers must be ignored to avoid firmware corruption
+    // more correct implementation would detect commands and only allow writes
+    // when enabled
+    // Almost certainly applies to many other cams
+    if (strcmp(s->model->name, MODEL_NAME_A1100) == 0) {
+        // actual firmware addresses are ffc* as above, but qemu sees 0xf8*
+        if(address == 0xf8000aaa ||  address == 0xf8000554)  {
+            msg = "Flash control";
+            goto end;
+        }
+    }
+
     switch(size)
     {
         case 1:

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -5653,8 +5653,14 @@ unsigned int eos_handle_display(unsigned int parm, unsigned int address, unsigne
     {
         case 0x014:
         {
+            // A1100 expects 0x4 or 0x8, 0x4 appears to be normal case in INT 0x68 handler ffc2ba64
+            // avoids assert from TakeSemaphoreStrictly(0x2680) in ffc404e8
+            if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0) {
+                ret = 0x4;
+            } else {
             /* 5D3 1.2.3: expects 0x10 for built-in LCD and 0x4 for HDMI? */
-            ret = 0x10;
+                ret = 0x10;
+            }
             break;
         }
 

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -3431,7 +3431,9 @@ unsigned int eos_handle_gpio(unsigned int parm, unsigned int address, unsigned c
             msg = "MIC CONNECT";
             // A1100 this is related to startup key press (ffc3040c)
             if((strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0) && ((address & 0xFFFF) == 0x134)) {
+                msg = "A1100 start key";
                 ret = 0;
+                break;
             } else {
                 ret = 1;
             }
@@ -3477,6 +3479,7 @@ unsigned int eos_handle_gpio(unsigned int parm, unsigned int address, unsigned c
             } else if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0 ) {
                 msg = "PB startup";       /* indicates play switch startup ffc3040c */
                 ret = 1;
+                break;
             } else {
                 msg = "HDMI CONNECT";       /* 600D; likely other D4 models */
                 ret = 0;

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -3454,9 +3454,9 @@ unsigned int eos_handle_gpio(unsigned int parm, unsigned int address, unsigned c
                 uint32_t physw_mmio_bits[] = {
                     0x00000000, // unknown
                     0x0000FF00, // unpressed state of D-pad, Menu, PRINT
-                    0x000010F0, // unpressed state of zoom, shoot.
+                    0x000090F0, // unpressed state of zoom, shoot.
                                 // 0x1000 indicates video cable not connected
-                                // 0x00008000 may be battery door, unclear if used on AA cam
+                                // 0x8000 is battery / card door, must be set to boot (see ffc601cc)
                                 // upper half word of 3rd MMIO is ignored, corresponding
                                 // physw_status bits come from kbd_read_keys_r2 (ffc304a4)
                 };

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -1420,8 +1420,8 @@ static void eos_update_display(void *parm)
     int height_multiplier = 1;
     int out_height = height;
 
-    // VxWorks models have 720x240 screens stretched vertically
-    if (s->model->digic_version < 4)
+    // VxWorks models and some PowerShots have 720x240 screens stretched vertically
+    if (s->model->digic_version < 4 || strcmp(s->model->name, MODEL_NAME_A1100) == 0)
     {
         height_multiplier = 2;
         height /= height_multiplier;
@@ -5798,7 +5798,11 @@ unsigned int eos_handle_display(unsigned int parm, unsigned int address, unsigne
                 int entry = (((address & 0xFFF) - 0x400) / 4) % 0x100;
                 process_palette_entry(value, &eos_state->disp.palette_8bit[entry], entry, &msg);
                 eos_state->disp.is_4bit = 0;
-                eos_state->disp.bmp_pitch = 960;
+                if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0) {
+                    eos_state->disp.bmp_pitch = 720;
+                } else {
+                    eos_state->disp.bmp_pitch = 960;
+                }
             }
             break;
     }

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -547,7 +547,7 @@ EOSRegionHandler eos_handlers[] =
     { "SIO9",         0xC0820900, 0xC08209FF, eos_handle_sio, 9 },
     { "SIO10",        0xC0820A00, 0xC0820AFF, eos_handle_sio, 10 },
     // Digic 2-5 P&S ADC
-    { "ADC",          0xC0900040, 0xC09000B0, eos_handle_adc, 1 },
+    { "ADC",          0xC0900040, 0xC09000D4, eos_handle_adc, 1 },
     { "MREQ",         0xC0203000, 0xC02030FF, eos_handle_mreq, 0 },
     { "DMA1",         0xC0A10000, 0xC0A100FF, eos_handle_dma, 1 },
     { "DMA2",         0xC0A20000, 0xC0A200FF, eos_handle_dma, 2 },
@@ -3605,6 +3605,9 @@ unsigned int eos_handle_adc(unsigned int parm, unsigned int address, unsigned ch
                     // value seen on a540, 2xAA battery at 2.6v. LiPo camera at 4.2 = 0x2033c/
                     ret = 0x2024f;
                 }
+            } else if (off == 0xd4) {
+                msg = "ADC ready?";
+                ret = 0x0ffe000a; // A1100 ffc2dd28, related to ADC setup, avoid long busy loop polling MMIO. Value from D10
             }
         }
     }

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -3583,6 +3583,7 @@ unsigned int eos_handle_adc(unsigned int parm, unsigned int address, unsigned ch
                 }
             }
         }
+        // digic 2 - 5 P&S style
         else if (parm == 1)
         {
             unsigned int off = (address & 0xFF);
@@ -3601,8 +3602,8 @@ unsigned int eos_handle_adc(unsigned int parm, unsigned int address, unsigned ch
                     uint32_t adc_values[] = {
                        0,   // channel  0 0xc0900040 0 0x0
                        1,   // channel  1 0xc0900042 1 0x1
-    //                   803, // channel  2 0xc0900044 803 0x323 < vbat ~4.037v
-                       497, // value from A540 ~2.215v (2x AA battery cam like A1100)
+    //                   803, // channel  2 0xc0900044 803 0x323 < vbat ~4.037v (from LiPo battery D10)
+                       497, // channel  2 value from A540 ~2.215v (2x AA battery cam like A1100)
                        471, // channel  3 0xc0900046 471 0x1d7 < tccd ~15c
                        448, // channel  4 0xc0900048 448 0x1c0 < topt ~13c
                        422, // channel  5 0xc090004a 422 0x1a6 < tbat ~ 17c
@@ -3622,7 +3623,7 @@ unsigned int eos_handle_adc(unsigned int parm, unsigned int address, unsigned ch
                 msg = "bat voltage";
                 if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0) {
                     // avoids bad return value from ffc106ec, related to battery
-                    // value seen on a540, 2xAA battery at 2.6v. LiPo camera at 4.2 = 0x2033c/
+                    // value seen on a540, 2xAA battery at 2.6v. LiPo camera at 4.2 = 0x2033c
                     ret = 0x2024f;
                 }
             } else if (off == 0xd4) {

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -1863,6 +1863,25 @@ static void patch_EOSM5(void)
     MEM_WRITE_ROM(0xE115CF88+0x98, (uint8_t*) &one, 4);
 }
 
+/* patches are for firmware 100c, 100b should be compatible, uses identical CHDK build */
+static void patch_A1100(void)
+{
+    /* avoid immediate shutdown from temperature check at ffc104fc
+     * better fix would be to return sane ADC values for the MMIO
+     */
+    fprintf(stderr, "Patching 0xFFC10504 (temp check)\n");
+    uint32_t nop = 0xe1a00000; // NOP 00 00 a0 e1;
+    MEM_WRITE_ROM(0xFFC10504, (uint8_t*) &nop, 4);
+
+    /*
+    // trigger ROMSTARTER DISKBOOT etc checks
+    fprintf(stderr, "Patching 0xffff0750 (uart loopback)\n");
+    uint32_t nop = 0xe1a00000; // NOP 00 00 a0 e1;
+    MEM_WRITE_ROM(0xffff0750, (uint8_t*) &nop, 4);
+    */
+}
+
+
 static void eos_init_common(void)
 {
     eos_init_cpu();
@@ -1961,6 +1980,11 @@ static void eos_init_common(void)
     if (strcmp(eos_state->model->name, MODEL_NAME_EOSM5) == 0)
     {
         patch_EOSM5();
+    }
+
+    if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0)
+    {
+        patch_A1100();
     }
 
     if (eos_state->model->digic_version == 6)

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -1896,26 +1896,6 @@ static void patch_EOSM5(void)
     MEM_WRITE_ROM(0xE115CF88+0x98, (uint8_t*) &one, 4);
 }
 
-/* patches are for firmware 100c, 100b should be compatible, uses identical CHDK build */
-static void patch_A1100(void)
-{
-    /* avoid immediate shutdown from temperature check at ffc104fc
-     * not needed with 0xC09000xx ADC handler
-     */
-    /*
-    fprintf(stderr, "Patching 0xFFC10504 (temp check)\n");
-    uint32_t nop = 0xe1a00000; // NOP 00 00 a0 e1;
-    MEM_WRITE_ROM(0xFFC10504, (uint8_t*) &nop, 4);
-    */
-
-    /*
-    // trigger ROMSTARTER DISKBOOT etc checks
-    fprintf(stderr, "Patching 0xffff0750 (uart loopback)\n");
-    uint32_t nop = 0xe1a00000; // NOP 00 00 a0 e1;
-    MEM_WRITE_ROM(0xffff0750, (uint8_t*) &nop, 4);
-    */
-}
-
 
 static void eos_init_common(void)
 {
@@ -2015,11 +1995,6 @@ static void eos_init_common(void)
     if (strcmp(eos_state->model->name, MODEL_NAME_EOSM5) == 0)
     {
         patch_EOSM5();
-    }
-
-    if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0)
-    {
-        patch_A1100();
     }
 
     if (eos_state->model->digic_version == 6)

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -4306,7 +4306,7 @@ handle SIO related to optical image stabilization system
 probably common for other DryOS R31 era P&S with OIS. Later Digic IV cams are different
 communication is generally like other SIO, but with some IS specific interrupts and registers
 */
-static unsigned int eos_handle_A1100_is_com(unsigned int parm, unsigned int address, unsigned char type, unsigned int value)
+static unsigned int eos_handle_A1100_IS_com(unsigned int parm, unsigned int address, unsigned char type, unsigned int value)
 {
     unsigned int ret = 0;
     const char *msg = NULL;
@@ -4447,7 +4447,7 @@ static unsigned int eos_handle_A1100_is_com(unsigned int parm, unsigned int addr
 unsigned int eos_handle_sio(unsigned int parm, unsigned int address, unsigned char type, unsigned int value)
 {
     if ((address & 0xFFFFFF00) == 0xC0820400 && strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0) {
-        return eos_handle_A1100_is_com(parm, address, type, value);
+        return eos_handle_A1100_IS_com(parm, address, type, value);
     }
 
     if (eos_state->sf && parm == eos_state->model->serial_flash_sio_ch)
@@ -5208,7 +5208,7 @@ unsigned int eos_handle_adtg_dma(unsigned int parm, unsigned int address, unsign
 A1100 appears to use MMIOs 0xc0500040-0xc0500058 to load optical image stabilization firmware, see ffcf5bf8
 Note 0xc05000A0 - 0xc05000B0 are used for apparently similar transfers for other devices in ffc32830
 */
-static unsigned int eos_handle_A1100_is_init(unsigned int parm, unsigned int address, unsigned char type, unsigned int value)
+static unsigned int eos_handle_A1100_IS_init(unsigned int parm, unsigned int address, unsigned char type, unsigned int value)
 {
     unsigned int ret = 0;
     const char *msg = NULL;
@@ -5238,7 +5238,7 @@ static unsigned int eos_handle_A1100_is_init(unsigned int parm, unsigned int add
                 msg = "ISInit unk2 trigger int";
                 // int that releases semaphore 0x55a4 in ffcf5bf8, unclear whether actually
                 // triggered by this transfer in real firmware
-                // this int is also triggered from eos_handle_A1100_is_com, but only later
+                // this int is also triggered from eos_handle_A1100_IS_com, but only later
                 eos_trigger_int(0x51, 0);
                 init_done = 1;
             } else {
@@ -5258,7 +5258,7 @@ unsigned int eos_handle_cfdma(unsigned int parm, unsigned int address, unsigned 
     // A1100 uses 0xc0500040 - 58, related to IS system, see ffcf5bf8
     if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0
         && address >= 0xc0500040 &&  address <= 0xc0500058) {
-        return eos_handle_A1100_is_init(parm,address,type,value);
+        return eos_handle_A1100_IS_init(parm,address,type,value);
     }
 
     switch(address & 0x1F)

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -3496,7 +3496,9 @@ unsigned int eos_handle_gpio(unsigned int parm, unsigned int address, unsigned c
             if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0 ) {
                 uint32_t physw_mmio_bits[] = {
                     0x00000000, // unknown
-                    0x0000FF00, // unpressed state of D-pad, Menu, PRINT
+                    0x0001FF00, // 0xFF00 = unpressed state of D-pad, Menu, PRINT,
+                                // + 0x10000 unknown, avoids most keys disabled at startup by ffc11184
+                                // setting event 0x8000001a, checked in ffc5c918
                     0x000090F0, // unpressed state of zoom, shoot.
                                 // 0x1000 indicates video cable not connected
                                 // 0x8000 is battery / card door, must be set to boot (see ffc601cc)

--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -3550,7 +3550,7 @@ unsigned int eos_handle_adc(unsigned int parm, unsigned int address, unsigned ch
                        1,   // channel  8 0xc0900050 1 0x1
                        1,   // channel  9 0xc0900052 1 0x1
                        565, // channel 10 0xc0900054 565 0x235
-                       524, // channel 11 0xc0900056 524 0x20c
+                       1,   // channel 11 0xc0900056 1 (USB not present) - 524 0x20c (USB present)
                     };
                     if (channel >= 0 && channel < COUNT(adc_values))
                     {

--- a/hw/eos/model_list.c
+++ b/hw/eos/model_list.c
@@ -257,6 +257,8 @@ struct eos_model_desc eos_model_list[] = {
         .mmio_size              = 0x01000000,
         .card_led_address       = 0xC02200CC,
         .current_task_addr      = 0x195C,
+        .sd_driver_interrupt    = 0x4b, // gdb log "SdConInt"
+        .sd_dma_interrupt       = 0x32, // gdb log "SdDmaInt"
     },
 /*************************** DIGIC V **********************************/
     {

--- a/hw/eos/model_list.c
+++ b/hw/eos/model_list.c
@@ -250,7 +250,7 @@ struct eos_model_desc eos_model_list[] = {
     {
         .name                   = MODEL_NAME_A1100,
         .digic_version          = 4,
-        .rom0_size              = 0x400000,     /* fixme: unknown */
+        .rom0_size              = 0x0,     /* A1100 has only one ROM */
         .rom1_size              = 0x400000,     /* 4MB */
         .ram_size               = 0x04000000,   /* only 64M */
         .btcm_addr              = 0x80000000,

--- a/hw/eos/model_list.c
+++ b/hw/eos/model_list.c
@@ -259,6 +259,8 @@ struct eos_model_desc eos_model_list[] = {
         .current_task_addr      = 0x195C,
         .sd_driver_interrupt    = 0x4b, // gdb log "SdConInt"
         .sd_dma_interrupt       = 0x32, // gdb log "SdDmaInt"
+        .rtc_cs_register        = 0xC0223010, // different from other cams, 0x800 set seems to indicate RTC selected
+                                              // set in ffc2d6d0, cleared in ffc2d700
     },
 /*************************** DIGIC V **********************************/
     {

--- a/magiclantern/cam_config/A1100/debugmsg.gdb
+++ b/magiclantern/cam_config/A1100/debugmsg.gdb
@@ -5,8 +5,12 @@ source -v debug-logging.gdb
 macro define CURRENT_TASK 0x195C
 macro define CURRENT_ISR  (MEM(0x670) ? MEM(0x674) >> 2 : 0)
 
+# LogCameraEvent
+b *0xffc56598
+DebugMsg1_log
+
 b *0xFFC0B284
-assert_log
+assert0_log
 
 b *0xFFC0AFAC
 task_create_log

--- a/magiclantern/cam_config/A1100/debugmsg.gdb
+++ b/magiclantern/cam_config/A1100/debugmsg.gdb
@@ -350,7 +350,9 @@ end
 # the key used to start the camera is unknown
 # In emulation, the firmware errors in shooting mode because lens hardware
 # is not emulated.
-b *0x34e5bc
+# this function isn't related to the value, it's just called between where CHDK
+# sets the incorrect value and where the value is used
+b *0xFFC090B4
 commands
  set MEM(0x2234) = 0x200000
  c

--- a/magiclantern/cam_config/A1100/debugmsg.gdb
+++ b/magiclantern/cam_config/A1100/debugmsg.gdb
@@ -5,6 +5,267 @@ source -v debug-logging.gdb
 macro define CURRENT_TASK 0x195C
 macro define CURRENT_ISR  (MEM(0x670) ? MEM(0x674) >> 2 : 0)
 
+# CHDK stubs levent_table
+macro define LEVENT_TABLE 0xffe93cdc
+
+# global error flag set by panic, assert, HardwareDefect, silences subsequent errors
+macro define ERROR_FLAG MEM(0x2954)
+
+# table structure is
+# char *name // may point to empty string
+# int event_id
+# int param
+# terminated by null (not empty) name, event id
+define ps_print_event_name
+  if LEVENT_TABLE != -1
+    set $p_ev_name = LEVENT_TABLE
+	while *(char **)($p_ev_name) != 0
+	  set $ev_name = *(char **)($p_ev_name)
+	  if *(int *)($p_ev_name + 4) == $arg0
+		if ((char *)$ev_name)[0] != 0
+		  printf "%s",$ev_name
+		end
+		loop_break
+	  end
+	  set $p_ev_name = $p_ev_name + 12
+	end
+  end
+end
+document ps_print_event_name
+Print name of numbered event if found in LEVENT_TABLE
+end
+
+define ps_event_dispatch_log
+  commands
+    silent
+    print_current_location
+    printf "Event(0x%X, 0x%X, 0x%X) ", $r0, $r1, $r2
+	ps_print_event_name $r0
+	printf "\n"
+    c
+  end
+end
+document ps_event_dispatch_log
+Log powershot controller events
+end
+
+define ps_event_post_log
+  commands
+    silent
+    print_current_location
+    printf "PostEvent(0x%X, 0x%X) ", $r0, $r1
+	ps_print_event_name $r0
+	printf "\n"
+    c
+  end
+end
+document ps_event_post_log
+Log powershot controller events posted from PostLogicalEventToUI and friends
+end
+
+define ps_cameracon_set_state_log
+  commands
+    silent
+    print_current_location
+    printf "cameracon_set_state(0x%X)\n", $r0
+    c
+  end
+end
+document ps_cameracon_set_state_log
+Log powershot cameracon state changes
+end
+
+define exception_logX
+  commands
+    silent
+    print_current_location
+    KRED
+    printf "exception(0x%X, 0x%X ,0x%X)\n", $r0, $r1, $r2
+    KRESET
+    c
+  end
+end
+document exception_logX
+Log exception function called early in exception vector code
+end
+
+define exception_log
+  commands
+    silent
+    print_current_location
+    KRED
+    printf "exception(0x%X) errflag=%d\n", $r0, ERROR_FLAG
+    KRESET
+    c
+  end
+end
+document exception_log
+Log exception function for DryOS handler registered by task_Startup:ffc15f3c
+end
+
+define hwdefect_log
+  commands
+    silent
+    print_current_location
+    KRED
+    printf "HardwareDefect(0x%X) errflag=%d\n", $r0, ERROR_FLAG
+    KRESET
+    c
+  end
+end
+document hwdefect_log
+Log HardwareDefect
+end
+
+define errflag_log
+  commands
+    silent
+    print_current_location
+    KRED
+    printf "SetErrFlag\n"
+    KRESET
+    c
+  end
+end
+document errflag_log
+Log function that sets global error flag
+end
+
+define asserthandler_log
+  commands
+    silent
+    print_current_location
+    KRED
+    printf "Assert handler(0x%X,%d) errflag=%d\n", $r0, $r1, ERROR_FLAG
+    KRESET
+    c
+  end
+end
+document asserthandler_log
+Log Dryos assert handler registered in task_Startup:ffc15f3c
+end
+
+define panic_log
+  commands
+    silent
+    print_current_location
+    KRED
+    printf "Panic(0x%X,0x%X) errflag=%d\n", $r0, $r1, ERROR_FLAG
+    KRESET
+    c
+  end
+end
+document panic_log
+Log Dryos panic
+end
+
+
+define printf_log0
+  commands
+    silent
+    print_current_location
+    print_formatted_string $r0 $r1 $r2 $r3 MEM($sp) MEM($sp+4) MEM($sp+8) MEM($sp+12) MEM($sp+16) MEM($sp+20)
+    c
+  end
+end
+document printf_log0
+Log calls to plain printf with format in r0.
+end
+
+define func_log
+  print_current_location
+  set $i = 0
+  while $i < $argc
+    eval "echo $arg%d", $i
+	printf " "
+	set $i = $i + 1
+  end
+  printf "P=0x%08x S=0x%08x I=%d M=0x%02x\n", $pc, $sp, ($cpsr & 0x80) >> 8, $cpsr&0x1f
+  printf "R0=0x%08x R1=0x%08x R2=0x%08x R3=0x%08x R4=0x%08x R5=0x%08x R6=0x%08x\n", $r0, $r1, $r2, $r3, $r4, $r5, $r6
+  x/12wx $sp
+end
+document func_log
+log optional message, summary of regs, stack
+end
+
+define func_logb
+  print_current_location
+  set $i = 0
+  while $i < $argc
+    eval "echo $arg%d", $i
+	printf " "
+	set $i = $i + 1
+  end
+  printf "P=0x%08x S=0x%08x 0x%08x 0x%08x 0x%08x 0x%08x\n", $pc, $sp, $r0, $r1, $r2, $r3
+end
+document func_log
+log optional message, brief summary of r0-r4
+end
+
+define bootparam_set_log
+  commands
+    silent
+    print_current_location
+    KGRN
+    printf "bootparam_set(0x%X, 0x%X)\n", $r0, $r1
+    KRESET
+    c
+  end
+end
+document bootparam_set_log
+Log calls bootparam set function
+end
+
+define ps_controller_log
+  commands
+    silent
+    print_current_location
+    KGRN
+    printf "controller(0x%X, 0x%X ,0x%X, 0x%X) @0x%x\n", $r0, $r1, $r2, $r4, $pc
+    KRESET
+    c
+  end
+end
+document ps_controller_log
+log controller calls
+end
+
+define dump_sio_com_struct
+ set $i=0
+ while $i < 8
+  set $ptr=(0x80000580 + 48*$i)
+  if $arg0 == *(int *)$ptr
+   printf "found SIO %d index %d\n", $arg0, $i
+   x/12wx $ptr
+   set $i=9
+  else
+   set $i=$i+1
+  end
+ end
+ if $i == 8
+  printf "sio %d not found\n", $arg0
+ end
+end
+document dump_sio_com_struct
+debug print tcm structure used for SIO com by 0x120 and friends
+end
+
+define dump_all_sio_com_struct
+ set $i=0
+ while $i < 8
+  set $ptr=(0x80000580 + 48*$i)
+  printf "index %d SIO %d\n", $i, *($ptr)
+  x/12wx $ptr
+  set $i=$i+1
+ end
+end
+document dump_all_sio_com_struct
+debug print tcm structures used for SIO com by 0x120 and friends
+end
+
+macro define CURRENT_TASK 0x195C
+macro define CURRENT_ISR  (MEM(0x670) ? MEM(0x674) >> 2 : 0)
+
 # LogCameraEvent
 b *0xffc56598
 DebugMsg1_log
@@ -20,5 +281,79 @@ register_interrupt_log
 
 b *0xFFC55494
 register_func_log
+
+b *0xffc5bf38
+ps_event_dispatch_log
+
+# PostLogicalEventToUi
+b *0xffc5c35c
+ps_event_post_log
+
+# PostLogicalEventForNotPowerType
+b *0xffc5c310
+ps_event_post_log
+
+# PostEventShootSeqToUI
+b *0xffc5c3d4
+ps_event_post_log
+
+# Unknown event post
+b *0xffd187a0
+ps_event_post_log
+
+b *0xffc5e1a8
+ps_cameracon_set_state_log
+
+# used by exception, dryos init errors
+b *0xffc03530
+printf_log0
+
+# on exception in handler called from exception vector
+#b *0xffc00d3c
+#exception_logX
+
+# on exception in handler registered at dryos startup
+b *0xffc4f9cc
+exception_log
+
+b *0xffc5cf84
+hwdefect_log
+
+b *0xffc4f5bc
+errflag_log
+
+b *0xffc4f620
+asserthandler_log
+
+b *0xffc4fd2c
+panic_log
+
+# set value in bootParam.c
+b *0xffc5d864
+bootparam_set_log
+
+# controller that deals with many startup events
+#b *0xffc19014
+#ps_controller_log
+
+# WriteToRom_FW
+b *0xffcff10c
+commands
+ silent
+ func_logb WriteToRom
+ c
+end
+
+# fix playback startup flag in CHDK
+# this is a workaround for a likely (but not yet confirmed on real hardware) bug
+# in the CHDK A1100 port, which causes CHDK to boot in shooting mode when
+# the key used to start the camera is unknown
+# In emulation, the firmware errors in shooting mode because lens hardware
+# is not emulated.
+b *0x34e5bc
+commands
+ set MEM(0x2234) = 0x200000
+ c
+end
 
 cont


### PR DESCRIPTION
### Changes to allow A1100 to boot to GUI in playback mode without fatal errors
Most changes are  isolated to A1100 by checking `eos_state->model->name`. Many would likely apply to other PowerShots of similar generation and possibly other Digic 4 cams. A1100 addresses in the comments refer to the 100c firmware.

Significant changes are

- ADC implementation for temperatures and voltages required by firmware (474b9a3, c3ed514, eef7d68)
- GPIOs for keyboard and other switch state (89031ae, 0a2b0c5, 8046419)
- Emulate IS system communication to allow startup (d89d4b0, ebac530)
- Work around firmware issued SD card command sequence triggering error state in qemu SD emulation (f45c532)
- Emulate RTC to avoid "set clock" prompt on startup (067e2d7)
- Avoid flash memory control register access corrupting ROM (56373f8)

### Status of A1100 support with these changes
The stock firmware boots in playback mode without errors, and runs indefinitely or until the Canon auto-poweroff setting in the firmware image times out.  If switched to shooting mode, the firmware shuts down with the Lens Error.

CHDK boots from a suitably prepared SD card image, but needs either the memory patch applied in debugmsg.gdb, or a custom CHDK build to avoid immediately switching to shooting mode.

The SD card lock state is currently hard coded to locked, since this is required to boot DISKBOOT.BIN. A future change should tie the lock state to the command line boot option.

Since PowerShot keyboards directly access GPIOs (rather than using an MPU), the qemu keyboard interface is non-functional. However, serial console eventshell can be used to send button events to the Canon firmware using UI.CreatePublic and then Press*Button* Unpress*Button* etc. This cannot be used to control CHDK, which reads GPIOs directly.