### PR TITLE
A1100 - avoid SD corruption caused by double calls to sdio_write_data

### DIFF
--- a/hw/eos/eos.c
+++ b/hw/eos/eos.c
@@ -5008,6 +5008,10 @@ unsigned int eos_handle_sdio(unsigned int parm, unsigned int address, unsigned c
         case 0x14:
             msg = "irq enable?";
             MMIO_VAR(eos_state->sd.irq_flags);
+            /* A1100 uses both the SDDMA reg 0x10 as described below and this one, break to avoid double write */
+            if (strcmp(eos_state->model->name, MODEL_NAME_A1100) == 0) {
+                break;
+            }
 
             /* sometimes, a write command ends with this register
              * other times, it ends with SDDMA register 0x10 (mask 0x1F)


### PR DESCRIPTION
This avoids filesystem corruption on SD write. Without the fix, pretty much any write corrupts the SD filesystem. This can be reproduced using the serial console with:
```
UI.Create
UIFS_WriteFirmInfoToFile 0
````
The bug isn't specific to UIFS_WriteFirmInfoToFile, it's just a convenient function which can be called from the console and writes a ~220 byte file called FirmInfo.txt in the SD root, using the stdio-like _Fut functions.

The corruption triggered by the above typically included a duplicate FAT entry for FirmInfo.txt, as well as other problems reported by fsck.fat
 
Note in the current qemu-eos-4.2.1 branch A1100 code, the SD write protect bit is hard coded on via the default return of eos_handle_gpio, so to write anything you either need to make 0xC0223024 read 0, or run CHDK which overrides the OS view of the SD lock (but beware the CHDK lock override fails intermittently in qemu due to unrelated issues).

The double write problem may well apply to other cameras. Aside from filesystem corruption, this can be verified by checking whether a single sector level write (e.g. a1100 WriteSDCard ffce4748 with a count of 1 triggers both the eos_handle_sdio and eos_handle_sddma cases that call sdio_write_data.

There's probably a cleaner, more general way to fix this, perhaps by avoiding the eos_handle_sdio case if DMA was used in the most recent write, but the approach here fixes the immediate problem and avoids impacting other cameras.